### PR TITLE
Display external ports on Docker service cards

### DIFF
--- a/public/js/app/main.js
+++ b/public/js/app/main.js
@@ -41,6 +41,7 @@ function App() {
   const [editingTitle, setEditingTitle] = React.useState("");
 
   const [billingCfg, setBillingCfg] = React.useState(null);
+  const [services, setServices] = React.useState([]);
 
   // Loja
   const [storeOpen, setStoreOpen] = React.useState(false);
@@ -57,6 +58,22 @@ function App() {
     const open = () => setAboutOpen(true);
     window.addEventListener("open-about-modal", open);
     return () => window.removeEventListener("open-about-modal", open);
+  }, []);
+
+  React.useEffect(() => {
+    let disposed = false;
+    fetch("/api/compose/services")
+      .then((r) => (r.ok ? r.json() : []))
+      .then((data) => {
+        if (disposed) return;
+        setServices(Array.isArray(data) ? data : []);
+      })
+      .catch(() => {
+        if (!disposed) setServices([]);
+      });
+    return () => {
+      disposed = true;
+    };
   }, []);
 
   // Auth refs
@@ -502,6 +519,97 @@ function App() {
         e("i", { className: "ph-bold ph-sign-out" })
       )
     ),
+
+    // docker compose services
+    services.length > 0 &&
+      e(
+        "section",
+        { className: "docker-services" },
+        e(
+          "div",
+          { className: "docker-services__grid" },
+          services.map((svc) => {
+            const title =
+              svc?.containerName || svc?.name || svc?.label || svc?.id;
+            const subtitle =
+              svc?.label && svc.label !== title ? svc.label : null;
+            const image = svc?.image || svc?.imageName || null;
+            const hostPort =
+              svc?.externalPort ?? svc?.hostPort ?? svc?.port ?? null;
+            const internalPort =
+              svc?.internalPort ?? svc?.containerPort ?? svc?.targetPort ?? null;
+            const protocol = svc?.protocol ?? svc?.scheme ?? null;
+            const note = svc?.note ?? null;
+            const statusColor = svc?.statusColor || "#2ecc71";
+            const statusLabel =
+              svc?.statusLabel || "Status reportado pelo Docker Compose.";
+
+            const portChildren = [];
+            if (hostPort !== null && hostPort !== undefined && hostPort !== "") {
+              portChildren.push("Porta externa: ");
+              portChildren.push(
+                e("strong", { key: "ext" }, String(hostPort))
+              );
+              if (internalPort) {
+                portChildren.push(` → ${internalPort}`);
+              }
+              if (protocol) {
+                portChildren.push(` (${String(protocol).toUpperCase()})`);
+              }
+            } else if (internalPort) {
+              portChildren.push(
+                `Sem porta externa • Porta interna ${internalPort}`
+              );
+            } else {
+              portChildren.push("Sem portas expostas");
+            }
+
+            return e(
+              "article",
+              {
+                key: svc?.id || title,
+                className: "docker-services__card",
+              },
+              e(
+                "header",
+                { className: "docker-services__card-header" },
+                e("span", {
+                  className: "docker-services__status",
+                  style: { backgroundColor: statusColor },
+                  title: statusLabel,
+                }),
+                e("i", {
+                  className: "ph-bold ph-docker-logo",
+                  "aria-hidden": "true",
+                }),
+                e(
+                  "div",
+                  { className: "docker-services__names" },
+                  e("strong", null, title),
+                  subtitle && e("span", null, subtitle)
+                )
+              ),
+              image &&
+                e(
+                  "div",
+                  { className: "docker-services__image" },
+                  image
+                ),
+              e(
+                "div",
+                { className: "docker-services__port" },
+                portChildren
+              ),
+              note &&
+                e(
+                  "div",
+                  { className: "docker-services__note" },
+                  note
+                )
+            );
+          })
+        )
+      ),
 
     /* ... (resto permanece igual: abas, menu long-press, add task e lista) ... */
     // tabs

--- a/public/style.css
+++ b/public/style.css
@@ -203,6 +203,86 @@ input[type="checkbox"] {
   color: #fff;
 }
 
+/* Docker services */
+.docker-services {
+  width: 100%;
+  max-width: 960px;
+  margin: 1.5rem auto;
+}
+
+.docker-services__grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.docker-services__card {
+  background: #111;
+  border: 2px solid #f1c40f44;
+  border-radius: 12px;
+  padding: 1rem;
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.docker-services__card-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #f1c40f;
+  font-size: 0.95rem;
+}
+
+.docker-services__status {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  box-shadow: 0 0 6px rgba(46, 204, 113, 0.8);
+  background: #2ecc71;
+}
+
+.docker-services__names {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.docker-services__names strong {
+  font-size: 1rem;
+  color: #fff;
+}
+
+.docker-services__names span {
+  font-size: 0.8rem;
+  color: #f1c40fcc;
+}
+
+.docker-services__image {
+  font-size: 0.85rem;
+  opacity: 0.75;
+}
+
+.docker-services__port {
+  font-size: 0.9rem;
+  color: #f1c40f;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.docker-services__port strong {
+  font-size: 1.05rem;
+}
+
+.docker-services__note {
+  font-size: 0.8rem;
+  color: #f1c40fcc;
+  line-height: 1.35;
+}
+
 /* Password strength meter */
 .pw-meter {
   display: grid;

--- a/server.js
+++ b/server.js
@@ -47,6 +47,57 @@ app.use("/api", createBillingRoutes({ auth, stripe }));
 app.use("/api", createTabsRoutes({ auth }));
 app.use("/api", createTasksRoutes({ auth }));
 
+app.get("/api/compose/services", (req, res) => {
+  const projectName =
+    process.env.COMPOSE_PROJECT_NAME || path.basename(process.cwd());
+  const toPort = (value, fallback = null) => {
+    if (value === undefined || value === null || value === "") {
+      return fallback;
+    }
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? n : value;
+  };
+
+  const services = [
+    {
+      id: "web",
+      label: "Web",
+      containerName: `${projectName}-web-1`,
+      image: `${projectName}-web:latest`,
+      internalPort: 3000,
+      externalPort: toPort(process.env.WEB_PORT, 3000),
+      protocol: "http",
+      note: "Interface principal do app.",
+    },
+    {
+      id: "studio",
+      label: "Prisma Studio",
+      containerName: `${projectName}-studio-1`,
+      image: `${projectName}-studio:latest`,
+      internalPort: 5555,
+      externalPort: toPort(process.env.PRISMA_STUDIO_PORT, 5555),
+      protocol: "http",
+      note: "Ferramenta de inspeção do banco de dados.",
+    },
+    {
+      id: "db",
+      label: "PostgreSQL",
+      containerName: `${projectName}-db-1`,
+      image: "postgres:14",
+      internalPort: 5432,
+      externalPort:
+        toPort(
+          process.env.POSTGRES_EXTERNAL_PORT || process.env.POSTGRES_PORT,
+          null
+        ),
+      protocol: "tcp",
+      note: "Banco acessível apenas internamente por padrão.",
+    },
+  ];
+
+  res.json(services);
+});
+
 // me
 app.get("/api/me", auth, async (req, res) => {
   res.json({


### PR DESCRIPTION
## Summary
- add an `/api/compose/services` endpoint that exposes docker-compose port metadata derived from environment variables
- load the compose service list on the client and render cards with the mapped external ports when available
- style the new docker service cards to match the existing UI while highlighting the exposed port information

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cf03136bc4832c893e4c189df3735e